### PR TITLE
fix: prevent overflow with ignoreUnknownKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+- Fixed `ignoreUnknownKeys` behavior in nested structures ([#82][i82] and [#87][p87])
 
 ## [0.5.3] - 2022-10-23
 - Fixed `strictTypes` flag to allow all number conversions and not just different precisions ([#81][i81])
@@ -107,7 +108,7 @@ MsgPack.default.encodeToByteArray(...)
 [0.5.0]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.4.4...0.5.0
 [0.5.1]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.0...0.5.1
 [0.5.2]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.1...0.5.2
-[0.5.2]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.2...0.5.3
+[0.5.3]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.2...0.5.3
 [i6]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/6
 [i9]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/9
 [i10]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/10
@@ -129,3 +130,4 @@ MsgPack.default.encodeToByteArray(...)
 [i81]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/81
 [i82]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/82
 [p40]: https://github.com/esensar/kotlinx-serialization-msgpack/pull/40
+[p87]: https://github.com/esensar/kotlinx-serialization-msgpack/pull/87

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
@@ -154,7 +154,7 @@ internal class MsgPackDecoderTest {
     @Test
     fun testSampleClassWithNestedValueAndMissingKeys() {
         TestData.nestedSampleClassWithMissingValue.forEach { (input, result) ->
-            val decoder = BasicMsgPackDecoder(MsgPackConfiguration.default, SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())
+            val decoder = BasicMsgPackDecoder(MsgPackConfiguration.default.copy(ignoreUnknownKeys = true), SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())
             val serializer = TestData.SampleClassWithNestedClass.serializer()
             assertEquals(result, serializer.deserialize(decoder))
         }
@@ -199,8 +199,8 @@ internal class MsgPackDecoderTest {
     private fun <RESULT> testPairs(decodeFunction: MsgPackDecoder.() -> RESULT, vararg pairs: Pair<String, RESULT>) {
         pairs.forEach { (input, result) ->
             MsgPackDecoder(BasicMsgPackDecoder(MsgPackConfiguration.default, SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())).also {
-            assertEquals(result, it.decodeFunction())
-        }
+                assertEquals(result, it.decodeFunction())
+            }
         }
     }
 }

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
@@ -157,7 +157,8 @@ object TestData {
         val testString: String,
         val testInt: Int,
         val testBoolean: Boolean,
-        val testNested: NestedClass
+        val testNested: NestedClass,
+        val secondNested: NestedClass? = null
     ) {
         @Serializable
         data class NestedClass(
@@ -183,7 +184,8 @@ object TestData {
         "83a56669727374a5416c696365a67365636f6e64a3426f62a57468697264a454657374" to Triple("Alice", "Bob", "Test")
     )
     val nestedSampleClassWithMissingValue = arrayOf(
-        "84aa74657374537472696e67a3646566a774657374496e747bab74657374426f6f6c65616ec3aa746573744e657374656482aa74657374537472696e67a3646566ab74657374426f6f6c65616ec3" to SampleClassWithNestedClass("def", 123, true, SampleClassWithNestedClass.NestedClass(null))
+        "84aa74657374537472696e67a3646566a774657374496e747bab74657374426f6f6c65616ec3aa746573744e657374656482aa74657374537472696e67a3646566ab74657374426f6f6c65616ec3" to SampleClassWithNestedClass("def", 123, true, SampleClassWithNestedClass.NestedClass(null)),
+        "85aa74657374537472696e67a3646566a774657374496e747bab74657374426f6f6c65616ec3aa746573744e657374656483aa74657374537472696e67a3646566ab74657374426f6f6c65616ec3ae616e6f74686572556e6b6e6f776ea474657374ac7365636f6e644e657374656481ab74657374426f6f6c65616ec2" to SampleClassWithNestedClass("def", 123, true, SampleClassWithNestedClass.NestedClass(null), SampleClassWithNestedClass.NestedClass(null)),
     )
 }
 


### PR DESCRIPTION
If `ignoreUnknownKeys` flag is on, reading could overflow to further structures and cause issues when these structures need to be parsed.

This closes #87
This fixes #82