### PR TITLE
added mac os arm64 target

### DIFF
--- a/serialization-msgpack-timestamp-extension/build.gradle.kts
+++ b/serialization-msgpack-timestamp-extension/build.gradle.kts
@@ -25,17 +25,10 @@ kotlin {
     iosSimulatorArm64()
     tvos()
     watchos()
-    val hostOs = System.getProperty("os.name")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    when {
-        hostOs == "Mac OS X" -> macosX64()
-        hostOs == "Linux" -> {
-            mingwX64() // cross-compile windows
-            linuxX64()
-        }
-        isMingwX64 -> mingwX64()
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
+    macosX64()
+    macosArm64()
+    mingwX64()
+    linuxX64()
 
     fun kotlinx(name: String, version: String): String = "org.jetbrains.kotlinx:kotlinx-$name:$version"
     fun kotlinxSerialization(name: String) = kotlinx("serialization-$name", Dependencies.Versions.serialization)

--- a/serialization-msgpack-unsigned-support/build.gradle.kts
+++ b/serialization-msgpack-unsigned-support/build.gradle.kts
@@ -25,17 +25,10 @@ kotlin {
     iosSimulatorArm64()
     tvos()
     watchos()
-    val hostOs = System.getProperty("os.name")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    when {
-        hostOs == "Mac OS X" -> macosX64()
-        hostOs == "Linux" -> {
-            mingwX64() // cross-compile windows
-            linuxX64()
-        }
-        isMingwX64 -> mingwX64()
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
+    macosX64()
+    macosArm64()
+    mingwX64()
+    linuxX64()
 
     fun kotlinx(name: String, version: String): String = "org.jetbrains.kotlinx:kotlinx-$name:$version"
     fun kotlinxSerialization(name: String) = kotlinx("serialization-$name", Dependencies.Versions.serialization)

--- a/serialization-msgpack/build.gradle.kts
+++ b/serialization-msgpack/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
     tvos()
     watchos()
     macosX64()
+    macosArm64()
     mingwX64()
     linuxX64()
 


### PR DESCRIPTION
added mac os arm64 as a target and adjusted targets to ensure builds include all desktop targets

Closes https://github.com/esensar/kotlinx-serialization-msgpack/issues/93