### PR TITLE
Configuration option to encode enums as ordinal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [0.5.4] - 2023-02-13
 - Fixed `ignoreUnknownKeys` behavior in nested structures ([#82][i82] and [#87][p87])
+- Updated kotlin version to `1.8.10`
 
 ## [0.5.3] - 2022-10-23
 - Fixed `strictTypes` flag to allow all number conversions and not just different precisions ([#81][i81])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
+## [0.5.4] - 2023-02-13
 - Fixed `ignoreUnknownKeys` behavior in nested structures ([#82][i82] and [#87][p87])
 
 ## [0.5.3] - 2022-10-23
@@ -96,7 +98,7 @@ MsgPack.default.encodeToByteArray(...)
 - `MsgPackDynamicSerializer` as placeholder for future [contextual serializer](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#contextual-serialization)
 - Full implementation of msgpack spec excluding extension types and bin format family
 
-[Unreleased]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.3...main
+[Unreleased]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.4...main
 [0.2.0]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.1.0...0.2.0
 [0.2.1]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.2.0...0.2.1
 [0.3.0]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.2.1...0.3.0
@@ -109,6 +111,7 @@ MsgPack.default.encodeToByteArray(...)
 [0.5.1]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.0...0.5.1
 [0.5.2]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.1...0.5.2
 [0.5.3]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.2...0.5.3
+[0.5.4]: https://github.com/esensar/kotlinx-serialization-msgpack/compare/0.5.3...0.5.4
 [i6]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/6
 [i9]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/9
 [i10]: https://github.com/esensar/kotlinx-serialization-msgpack/issues/10

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,6 @@
 object Dependencies {
     object Versions {
-        const val kotlin = "1.7.10"
+        const val kotlin = "1.8.10"
         const val serialization = "1.4.0"
         const val datetime = "0.4.0"
         const val ktlintGradle = "10.2.0"

--- a/serialization-msgpack-timestamp-extension/build.gradle.kts
+++ b/serialization-msgpack-timestamp-extension/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
             testTask {
                 useKarma {
                     useChromeHeadless()
-                    webpackConfig.cssSupport.enabled = true
                 }
             }
         }

--- a/serialization-msgpack-unsigned-support/build.gradle.kts
+++ b/serialization-msgpack-unsigned-support/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
             testTask {
                 useKarma {
                     useChromeHeadless()
-                    webpackConfig.cssSupport.enabled = true
                 }
             }
         }

--- a/serialization-msgpack/build.gradle.kts
+++ b/serialization-msgpack/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
             testTask {
                 useKarma {
                     useChromeHeadless()
-                    webpackConfig.cssSupport.enabled = true
                 }
             }
         }

--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/MsgPackConfiguration.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/MsgPackConfiguration.kt
@@ -37,7 +37,12 @@ data class MsgPackConfiguration(
      * Useful when only parts of data are of interest
      * false by default
      */
-    val ignoreUnknownKeys: Boolean = false
+    val ignoreUnknownKeys: Boolean = false,
+    /**
+     * Encode enum values as Ints corresponding to their ordinal values
+     * false by default
+     */
+    val ordinalEnums: Boolean = false
 ) {
     companion object {
         @JvmStatic

--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackDecoder.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackDecoder.kt
@@ -99,7 +99,7 @@ internal class BasicMsgPackDecoder(
 
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
         if (configuration.ordinalEnums) {
-            return msgUnpacker.unpackInt()
+            return msgUnpacker.unpackInt(configuration.strictTypes, configuration.preventOverflows)
         }
         return enumDescriptor.getElementIndex(decodeString())
     }

--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackDecoder.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackDecoder.kt
@@ -98,6 +98,9 @@ internal class BasicMsgPackDecoder(
     }
 
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
+        if (configuration.ordinalEnums) {
+            return msgUnpacker.unpackInt()
+        }
         return enumDescriptor.getElementIndex(decodeString())
     }
 

--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackEncoder.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackEncoder.kt
@@ -61,7 +61,7 @@ internal class BasicMsgPackEncoder(
 
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
         if (configuration.ordinalEnums) {
-            result.addAll(packer.packInt(index))
+            result.addAll(packer.packInt(index, configuration.strictTypeWriting))
         } else {
             result.addAll(packer.packString(enumDescriptor.getElementName(index), configuration.rawCompatibility))
         }

--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackEncoder.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackEncoder.kt
@@ -60,7 +60,11 @@ internal class BasicMsgPackEncoder(
     }
 
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
-        result.addAll(packer.packString(enumDescriptor.getElementName(index), configuration.rawCompatibility))
+        if (configuration.ordinalEnums) {
+            result.addAll(packer.packInt(index))
+        } else {
+            result.addAll(packer.packString(enumDescriptor.getElementName(index), configuration.rawCompatibility))
+        }
     }
 
     fun encodeByteArray(value: ByteArray) {

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
@@ -181,7 +181,7 @@ internal class MsgPackDecoderTest {
     @Test
     fun testEnumOrdinalDecode() {
         TestData.enumOrdinalTestPairs.forEach { (input, result) ->
-            val decoder = BasicMsgPackDecoder(MsgPackConfiguration(ordinalEnums = true), SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())
+            val decoder = BasicMsgPackDecoder(MsgPackConfiguration(ordinalEnums = true, strictTypes = true), SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())
             val serializer = Vocation.serializer()
             assertEquals(result, serializer.deserialize(decoder))
         }

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
@@ -179,6 +179,15 @@ internal class MsgPackDecoderTest {
     }
 
     @Test
+    fun testEnumOrdinalDecode() {
+        TestData.enumOrdinalTestPairs.forEach { (input, result) ->
+            val decoder = BasicMsgPackDecoder(MsgPackConfiguration(ordinalEnums = true), SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())
+            val serializer = Vocation.serializer()
+            assertEquals(result, serializer.deserialize(decoder))
+        }
+    }
+
+    @Test
     fun testDecodeIgnoreUnknownKeys() {
         TestData.unknownKeysTestPairs.forEach { (input, result) ->
             val decoder = BasicMsgPackDecoder(MsgPackConfiguration.default.copy(ignoreUnknownKeys = true), SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackEncoderTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackEncoderTest.kt
@@ -165,6 +165,16 @@ internal class MsgPackEncoderTest {
         }
     }
 
+    @Test
+    fun testEnumOrdinalEncode() {
+        TestData.enumOrdinalTestPairs.forEach { (result, input) ->
+            val encoder = BasicMsgPackEncoder(MsgPackConfiguration(ordinalEnums = true), SerializersModule {})
+            val serializer = Vocation.serializer()
+            serializer.serialize(encoder, input)
+            assertEquals(result, encoder.result.toByteArray().toHex())
+        }
+    }
+
     private fun <INPUT> testPairs(encodeFunction: MsgPackEncoder.(INPUT) -> Unit, vararg pairs: Pair<String, INPUT>) {
         pairs.forEach { (result, input) ->
             MsgPackEncoder(BasicMsgPackEncoder(MsgPackConfiguration.default, SerializersModule {})).also {

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackEncoderTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackEncoderTest.kt
@@ -168,7 +168,7 @@ internal class MsgPackEncoderTest {
     @Test
     fun testEnumOrdinalEncode() {
         TestData.enumOrdinalTestPairs.forEach { (result, input) ->
-            val encoder = BasicMsgPackEncoder(MsgPackConfiguration(ordinalEnums = true), SerializersModule {})
+            val encoder = BasicMsgPackEncoder(MsgPackConfiguration(ordinalEnums = true, strictTypeWriting = true), SerializersModule {})
             val serializer = Vocation.serializer()
             serializer.serialize(encoder, input)
             assertEquals(result, encoder.result.toByteArray().toHex())

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackTest.kt
@@ -298,7 +298,7 @@ internal class MsgPackTest {
         testEncodePairs(
             Vocation.serializer(),
             *TestData.enumOrdinalTestPairs,
-            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true))
+            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true, strictTypeWriting = true))
         )
     }
 
@@ -307,7 +307,7 @@ internal class MsgPackTest {
         testDecodePairs(
             Vocation.serializer(),
             *TestData.enumOrdinalTestPairs,
-            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true))
+            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true, strictTypes = true))
         )
     }
 

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackTest.kt
@@ -294,6 +294,24 @@ internal class MsgPackTest {
     }
 
     @Test
+    fun testEnumOrdinalEncode() {
+        testEncodePairs(
+            Vocation.serializer(),
+            *TestData.enumOrdinalTestPairs,
+            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true))
+        )
+    }
+
+    @Test
+    fun testEnumOrdinalDecode() {
+        testDecodePairs(
+            Vocation.serializer(),
+            *TestData.enumOrdinalTestPairs,
+            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true))
+        )
+    }
+
+    @Test
     fun testDecodeIgnoreUnknownKeys() {
         fun <T> testPairs(dataList: Array<Pair<String, T>>, serializer: KSerializer<T>) {
             dataList.forEach { (value, expectedResult) ->
@@ -372,14 +390,14 @@ internal class MsgPackTest {
         testPairs(TestData.strictWriteLongPairs, Long.serializer())
     }
 
-    private fun <T> testEncodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>) {
+    private fun <T> testEncodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>, msgPack: MsgPack = MsgPack()) {
         pairs.forEach { (expectedResult, value) ->
-            assertEquals(expectedResult, MsgPack.encodeToByteArray(serializer, value).toHex())
+            assertEquals(expectedResult, msgPack.encodeToByteArray(serializer, value).toHex())
         }
     }
-    private fun <T> testDecodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>) {
+    private fun <T> testDecodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>, msgPack: MsgPack = MsgPack()) {
         pairs.forEach { (value, expectedResult) ->
-            assertEquals(expectedResult, MsgPack.decodeFromByteArray(serializer, value.hexStringToByteArray()))
+            assertEquals(expectedResult, msgPack.decodeFromByteArray(serializer, value.hexStringToByteArray()))
         }
     }
 }

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
@@ -144,6 +144,12 @@ object TestData {
         "ab454c4445525f4452554944" to Vocation.ELDER_DRUID,
     )
 
+    val enumOrdinalTestPairs = arrayOf(
+        "0000000000" to Vocation.NONE,
+        "0000000001" to Vocation.DRUID,
+        "0000000100" to Vocation.ELDER_DRUID,
+    )
+
     @Serializable
     data class SampleClass(
         @SerialName("testString")

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
@@ -145,9 +145,9 @@ object TestData {
     )
 
     val enumOrdinalTestPairs = arrayOf(
-        "0000000000" to Vocation.NONE,
-        "0000000001" to Vocation.DRUID,
-        "0000000100" to Vocation.ELDER_DRUID,
+        "ce00000000" to Vocation.NONE,
+        "ce00000001" to Vocation.DRUID,
+        "ce00000005" to Vocation.ELDER_DRUID,
     )
 
     @Serializable


### PR DESCRIPTION
This PR introduces a configuration option `ordinalEnums` that, when enabled, causes enums to be encoded as `Int`s representing their ordinal value.

Closes https://github.com/esensar/kotlinx-serialization-msgpack/issues/97

It would be fantastic to get this merged and get a new release with this and support for the macosArm64 target