### PR TITLE
added support for ordinal enums

### DIFF
--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/MsgPackConfiguration.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/MsgPackConfiguration.kt
@@ -37,7 +37,12 @@ data class MsgPackConfiguration(
      * Useful when only parts of data are of interest
      * false by default
      */
-    val ignoreUnknownKeys: Boolean = false
+    val ignoreUnknownKeys: Boolean = false,
+    /**
+     * Encode enum values as Ints corresponding to their ordinal values
+     * false by default
+     */
+    val ordinalEnums: Boolean = false
 ) {
     companion object {
         @JvmStatic

--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackDecoder.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackDecoder.kt
@@ -98,6 +98,9 @@ internal class BasicMsgPackDecoder(
     }
 
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
+        if (configuration.ordinalEnums) {
+            return msgUnpacker.unpackInt(configuration.strictTypes, configuration.preventOverflows)
+        }
         return enumDescriptor.getElementIndex(decodeString())
     }
 

--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackEncoder.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/internal/MsgPackEncoder.kt
@@ -60,7 +60,11 @@ internal class BasicMsgPackEncoder(
     }
 
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
-        result.addAll(packer.packString(enumDescriptor.getElementName(index), configuration.rawCompatibility))
+        if (configuration.ordinalEnums) {
+            result.addAll(packer.packInt(index, configuration.strictTypeWriting))
+        } else {
+            result.addAll(packer.packString(enumDescriptor.getElementName(index), configuration.rawCompatibility))
+        }
     }
 
     fun encodeByteArray(value: ByteArray) {

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackDecoderTest.kt
@@ -179,6 +179,15 @@ internal class MsgPackDecoderTest {
     }
 
     @Test
+    fun testEnumOrdinalDecode() {
+        TestData.enumOrdinalTestPairs.forEach { (input, result) ->
+            val decoder = BasicMsgPackDecoder(MsgPackConfiguration(ordinalEnums = true, strictTypes = true), SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())
+            val serializer = Vocation.serializer()
+            assertEquals(result, serializer.deserialize(decoder))
+        }
+    }
+
+    @Test
     fun testDecodeIgnoreUnknownKeys() {
         TestData.unknownKeysTestPairs.forEach { (input, result) ->
             val decoder = BasicMsgPackDecoder(MsgPackConfiguration.default.copy(ignoreUnknownKeys = true), SerializersModule {}, input.hexStringToByteArray().toMsgPackBuffer())

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackEncoderTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackEncoderTest.kt
@@ -165,6 +165,16 @@ internal class MsgPackEncoderTest {
         }
     }
 
+    @Test
+    fun testEnumOrdinalEncode() {
+        TestData.enumOrdinalTestPairs.forEach { (result, input) ->
+            val encoder = BasicMsgPackEncoder(MsgPackConfiguration(ordinalEnums = true, strictTypeWriting = true), SerializersModule {})
+            val serializer = Vocation.serializer()
+            serializer.serialize(encoder, input)
+            assertEquals(result, encoder.result.toByteArray().toHex())
+        }
+    }
+
     private fun <INPUT> testPairs(encodeFunction: MsgPackEncoder.(INPUT) -> Unit, vararg pairs: Pair<String, INPUT>) {
         pairs.forEach { (result, input) ->
             MsgPackEncoder(BasicMsgPackEncoder(MsgPackConfiguration.default, SerializersModule {})).also {

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackTest.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/MsgPackTest.kt
@@ -294,6 +294,24 @@ internal class MsgPackTest {
     }
 
     @Test
+    fun testEnumOrdinalEncode() {
+        testEncodePairs(
+            Vocation.serializer(),
+            *TestData.enumOrdinalTestPairs,
+            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true, strictTypeWriting = true))
+        )
+    }
+
+    @Test
+    fun testEnumOrdinalDecode() {
+        testDecodePairs(
+            Vocation.serializer(),
+            *TestData.enumOrdinalTestPairs,
+            msgPack = MsgPack(MsgPackConfiguration(ordinalEnums = true, strictTypes = true))
+        )
+    }
+
+    @Test
     fun testDecodeIgnoreUnknownKeys() {
         fun <T> testPairs(dataList: Array<Pair<String, T>>, serializer: KSerializer<T>) {
             dataList.forEach { (value, expectedResult) ->
@@ -372,14 +390,14 @@ internal class MsgPackTest {
         testPairs(TestData.strictWriteLongPairs, Long.serializer())
     }
 
-    private fun <T> testEncodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>) {
+    private fun <T> testEncodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>, msgPack: MsgPack = MsgPack()) {
         pairs.forEach { (expectedResult, value) ->
-            assertEquals(expectedResult, MsgPack.encodeToByteArray(serializer, value).toHex())
+            assertEquals(expectedResult, msgPack.encodeToByteArray(serializer, value).toHex())
         }
     }
-    private fun <T> testDecodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>) {
+    private fun <T> testDecodePairs(serializer: KSerializer<T>, vararg pairs: Pair<String, T>, msgPack: MsgPack = MsgPack()) {
         pairs.forEach { (value, expectedResult) ->
-            assertEquals(expectedResult, MsgPack.decodeFromByteArray(serializer, value.hexStringToByteArray()))
+            assertEquals(expectedResult, msgPack.decodeFromByteArray(serializer, value.hexStringToByteArray()))
         }
     }
 }

--- a/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
+++ b/serialization-msgpack/src/commonTest/kotlin/com/ensarsarajcic/kotlinx/serialization/msgpack/TestData.kt
@@ -144,6 +144,12 @@ object TestData {
         "ab454c4445525f4452554944" to Vocation.ELDER_DRUID,
     )
 
+    val enumOrdinalTestPairs = arrayOf(
+        "ce00000000" to Vocation.NONE,
+        "ce00000001" to Vocation.DRUID,
+        "ce00000005" to Vocation.ELDER_DRUID,
+    )
+
     @Serializable
     data class SampleClass(
         @SerialName("testString")


### PR DESCRIPTION
This PR introduces a configuration option ordinalEnums that, when enabled, causes enums to be encoded as Ints representing their ordinal value.

Closes https://github.com/esensar/kotlinx-serialization-msgpack/issues/97

This PR replaces https://github.com/esensar/kotlinx-serialization-msgpack/pull/98