### PR TITLE
fix: optimizations reducing heap usage in MsgPackDataOutputBuffer

### DIFF
--- a/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/stream/MsgPackDataBuffer.kt
+++ b/serialization-msgpack/src/commonMain/kotlin/com.ensarsarajcic.kotlinx.serialization.msgpack/stream/MsgPackDataBuffer.kt
@@ -5,15 +5,34 @@ interface MsgPackDataBuffer {
 }
 
 class MsgPackDataOutputBuffer() : MsgPackDataBuffer {
-    private val bytes = mutableListOf<Byte>()
+    private val byteArrays = mutableListOf<ByteArray>()
 
-    fun add(byte: Byte) = bytes.add(byte)
+    fun add(byte: Byte) {
+        byteArrays.add(ByteArray(1) { byte })
+    }
 
-    fun addAll(bytes: List<Byte>) = this.bytes.addAll(bytes)
+    fun addAll(bytes: List<Byte>) {
+        if (bytes.isNotEmpty()) {
+            byteArrays.add(bytes.toByteArray())
+        }
+    }
 
-    fun addAll(bytes: ByteArray) = this.bytes.addAll(bytes.toList())
+    fun addAll(bytes: ByteArray) {
+        if (bytes.isNotEmpty()) {
+            byteArrays.add(bytes)
+        }
+    }
 
-    override fun toByteArray() = bytes.toByteArray()
+    override fun toByteArray(): ByteArray {
+        val totalSize = byteArrays.sumOf { it.size }
+        val outputArray = ByteArray(totalSize)
+        var currentIndex = 0
+        byteArrays.forEach {
+            it.copyInto(outputArray, currentIndex)
+            currentIndex += it.size
+        }
+        return outputArray
+    }
 }
 
 class MsgPackDataInputBuffer(private val byteArray: ByteArray) : MsgPackDataBuffer {


### PR DESCRIPTION
During performance analysis of the library we found the serialization creates a lot of Byte objects (each of them taking 16 bytes) when serializing byte arrays. This optimization reduces this overhead and significantly improves the memory overhead of the serializer. 